### PR TITLE
refactor: add configuration setting repository

### DIFF
--- a/src/AzureAppConfigurationEmulator/AzureAppConfigurationEmulator.csproj
+++ b/src/AzureAppConfigurationEmulator/AzureAppConfigurationEmulator.csproj
@@ -8,12 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="7.1.4"/>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-rc.1.23419.6">
+    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="8.1.5"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0-rc.1.23419.6"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0"/>
+    <PackageReference Include="System.Linq.Async" Version="6.0.1"/>
   </ItemGroup>
 
 </Project>

--- a/src/AzureAppConfigurationEmulator/Handlers/KeyHandler.cs
+++ b/src/AzureAppConfigurationEmulator/Handlers/KeyHandler.cs
@@ -1,20 +1,18 @@
 using System.Text.RegularExpressions;
 using AzureAppConfigurationEmulator.Constants;
-using AzureAppConfigurationEmulator.Contexts;
-using AzureAppConfigurationEmulator.Extensions;
+using AzureAppConfigurationEmulator.Repositories;
 using AzureAppConfigurationEmulator.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace AzureAppConfigurationEmulator.Handlers;
 
 public class KeyHandler
 {
     public static async Task<Results<KeySetResult, InvalidCharacterResult, TooManyValuesResult>> List(
-        [FromServices] ApplicationDbContext context,
-        CancellationToken cancellationToken,
-        [FromQuery] string name = KeyFilter.Any)
+        [FromServices] IConfigurationSettingRepository repository,
+        [FromQuery] string name = KeyFilter.Any,
+        CancellationToken cancellationToken = default)
     {
         if (name != KeyFilter.Any)
         {
@@ -29,8 +27,7 @@ public class KeyHandler
             }
         }
 
-        var keys = await context.ConfigurationSettings
-            .Where(key: name)
+        var keys = await repository.Get(key: name)
             .Select(setting => setting.Key)
             .Distinct()
             .ToListAsync(cancellationToken);

--- a/src/AzureAppConfigurationEmulator/Handlers/LabelHandler.cs
+++ b/src/AzureAppConfigurationEmulator/Handlers/LabelHandler.cs
@@ -1,20 +1,19 @@
 using System.Text.RegularExpressions;
 using AzureAppConfigurationEmulator.Constants;
-using AzureAppConfigurationEmulator.Contexts;
 using AzureAppConfigurationEmulator.Extensions;
+using AzureAppConfigurationEmulator.Repositories;
 using AzureAppConfigurationEmulator.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 
 namespace AzureAppConfigurationEmulator.Handlers;
 
 public class LabelHandler
 {
     public static async Task<Results<LabelSetResult, InvalidCharacterResult, TooManyValuesResult>> List(
-        [FromServices] ApplicationDbContext context,
-        CancellationToken cancellationToken,
-        [FromQuery] string name = LabelFilter.Any)
+        [FromServices] IConfigurationSettingRepository repository,
+        [FromQuery] string name = LabelFilter.Any,
+        CancellationToken cancellationToken = default)
     {
         if (name != LabelFilter.Any)
         {
@@ -29,8 +28,7 @@ public class LabelHandler
             }
         }
 
-        var labels = await context.ConfigurationSettings
-            .Where(label: name)
+        var labels = await repository.Get(label: name)
             .Select(setting => setting.Label.NormalizeNull())
             .Distinct()
             .ToListAsync(cancellationToken);

--- a/src/AzureAppConfigurationEmulator/Program.cs
+++ b/src/AzureAppConfigurationEmulator/Program.cs
@@ -3,6 +3,7 @@ using AzureAppConfigurationEmulator.Authentication;
 using AzureAppConfigurationEmulator.Contexts;
 using AzureAppConfigurationEmulator.Extensions;
 using AzureAppConfigurationEmulator.Handlers;
+using AzureAppConfigurationEmulator.Repositories;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +16,8 @@ builder.Services.AddDbContext<ApplicationDbContext>(builder =>
 {
     builder.UseSqlite($"Data Source={HostingExtensions.DatabasePath}");
 });
+
+builder.Services.AddScoped<IConfigurationSettingRepository, ConfigurationSettingRepository>();
 
 builder.Services.ConfigureHttpJsonOptions(options =>
 {

--- a/src/AzureAppConfigurationEmulator/Repositories/ConfigurationSettingRepository.cs
+++ b/src/AzureAppConfigurationEmulator/Repositories/ConfigurationSettingRepository.cs
@@ -1,16 +1,25 @@
 using System.Text.RegularExpressions;
 using AzureAppConfigurationEmulator.Constants;
+using AzureAppConfigurationEmulator.Contexts;
 using AzureAppConfigurationEmulator.Entities;
+using AzureAppConfigurationEmulator.Extensions;
 using LinqKit;
+using Microsoft.EntityFrameworkCore;
 
-namespace AzureAppConfigurationEmulator.Extensions;
+namespace AzureAppConfigurationEmulator.Repositories;
 
-public static class QueryableExtensions
+public class ConfigurationSettingRepository(ApplicationDbContext context) : IConfigurationSettingRepository
 {
-    public static IQueryable<ConfigurationSetting> Where(
-        this IQueryable<ConfigurationSetting> settings,
-        string key = KeyFilter.Any,
-        string label = LabelFilter.Any)
+    private ApplicationDbContext Context { get; } = context;
+
+    public async Task AddAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default)
+    {
+        Context.ConfigurationSettings.Add(setting);
+
+        await Context.SaveChangesAsync(cancellationToken);
+    }
+
+    public IAsyncEnumerable<ConfigurationSetting> Get(string key = KeyFilter.Any, string label = LabelFilter.Any)
     {
         var outer = PredicateBuilder.New<ConfigurationSetting>(true);
 
@@ -56,6 +65,20 @@ public static class QueryableExtensions
             outer = outer.And(inner);
         }
 
-        return settings.Where(outer);
+        return Context.ConfigurationSettings.Where(outer).AsAsyncEnumerable();
+    }
+
+    public async Task RemoveAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default)
+    {
+        Context.ConfigurationSettings.Remove(setting);
+
+        await Context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task UpdateAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default)
+    {
+        Context.ConfigurationSettings.Update(setting);
+
+        await Context.SaveChangesAsync(cancellationToken);
     }
 }

--- a/src/AzureAppConfigurationEmulator/Repositories/IConfigurationSettingRepository.cs
+++ b/src/AzureAppConfigurationEmulator/Repositories/IConfigurationSettingRepository.cs
@@ -1,0 +1,15 @@
+using AzureAppConfigurationEmulator.Constants;
+using AzureAppConfigurationEmulator.Entities;
+
+namespace AzureAppConfigurationEmulator.Repositories;
+
+public interface IConfigurationSettingRepository
+{
+    public Task AddAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default);
+
+    public IAsyncEnumerable<ConfigurationSetting> Get(string key = KeyFilter.Any, string label = LabelFilter.Any);
+
+    public Task RemoveAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default);
+
+    public Task UpdateAsync(ConfigurationSetting setting, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
**Describe the change**
This change adds a configuration setting repository which abstracts the Entity Framework Core database context.

**Current behavior**
The handlers depend on the database context which makes testing more difficult.

**New behavior**
The handlers depend on the configuration setting repository interface which allows for mocking.

**Additional context**
[Choosing a testing strategy - Repository pattern](https://learn.microsoft.com/en-us/ef/core/testing/choosing-a-testing-strategy#repository-pattern)