### PR TITLE
refactor: support signatures that exclude host header port

### DIFF
--- a/src/AzureAppConfigurationEmulator/Authentication/HmacHandler.cs
+++ b/src/AzureAppConfigurationEmulator/Authentication/HmacHandler.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Options;
 
 namespace AzureAppConfigurationEmulator.Authentication;
@@ -49,8 +49,7 @@ public class HmacHandler(IOptionsMonitor<HmacOptions> options, ILoggerFactory lo
         var parameters = value.Parameter.Split('&').ToDictionary(
             parameter => parameter[..parameter.IndexOf('=')],
             parameter => parameter[(parameter.IndexOf('=') + 1)..],
-            StringComparer.OrdinalIgnoreCase
-        );
+            StringComparer.OrdinalIgnoreCase);
 
         using (Logger.BeginScope(parameters))
         {
@@ -100,9 +99,7 @@ public class HmacHandler(IOptionsMonitor<HmacOptions> options, ILoggerFactory lo
             }
 
             Logger.LogDebug("Checking if the signature is valid.");
-
-            if (!CheckSignature(parameters, tryWithStrippingPort: false)
-                && !CheckSignature(parameters, tryWithStrippingPort: true))
+            if (!parameters[AuthenticationParameters.Signature].Equals(GetSignature(parameters[AuthenticationParameters.SignedHeaders]), StringComparison.Ordinal) && !parameters[AuthenticationParameters.Signature].Equals(GetSignature(parameters[AuthenticationParameters.SignedHeaders], false), StringComparison.Ordinal))
             {
                 return AuthenticateResult.Fail("Invalid signature");
             }
@@ -113,7 +110,7 @@ public class HmacHandler(IOptionsMonitor<HmacOptions> options, ILoggerFactory lo
                 Request.EnableBuffering();
 
                 Logger.LogDebug("Checking if the content hash is valid.");
-                if (!Request.Headers[HeaderNames.XMsContentSha256].ToString().Equals(Convert.ToBase64String(await SHA256.HashDataAsync(Request.Body)), StringComparison.Ordinal))
+                if (!Request.Headers[HeaderNames.XMsContentSha256].ToString().Equals(await ComputeContentHashAsync(Request.Body), StringComparison.Ordinal))
                 {
                     return AuthenticateResult.Fail("Invalid request content hash");
                 }
@@ -128,25 +125,6 @@ public class HmacHandler(IOptionsMonitor<HmacOptions> options, ILoggerFactory lo
         }
     }
 
-    private bool CheckSignature(IDictionary<string, string> parameters, bool tryWithStrippingPort)
-    {
-        var signedHeaders = parameters[AuthenticationParameters.SignedHeaders]
-            .Split(';')
-            .ToDictionary(i => i, i => Request.Headers[i].ToString(), StringComparer.OrdinalIgnoreCase);
-
-        if (tryWithStrippingPort && signedHeaders.TryGetValue(HeaderNames.Host, out var hostHeader) && hostHeader.Contains(':'))
-        {
-            // the .NET SDK has an issue when running locally where it doesn't include the port in the signed host header
-            signedHeaders[HeaderNames.Host] = hostHeader[..hostHeader.IndexOf(':')];
-        }
-
-        var signedHeadersPart = string.Join(';', parameters[AuthenticationParameters.SignedHeaders].Split(';').Select(header => signedHeaders[header]));
-        var stringToSign = $"{Request.Method}\n{Request.GetEncodedPathAndQuery()}\n{signedHeadersPart}";
-        var signature = Convert.ToBase64String(HMACSHA256.HashData(Convert.FromBase64String(Options.Secret), Encoding.ASCII.GetBytes(stringToSign)));
-
-        return parameters[AuthenticationParameters.Signature].Equals(signature, StringComparison.Ordinal);
-    }
-
     protected override async Task HandleChallengeAsync(AuthenticationProperties properties)
     {
         var result = await HandleAuthenticateOnceSafeAsync();
@@ -159,8 +137,58 @@ public class HmacHandler(IOptionsMonitor<HmacOptions> options, ILoggerFactory lo
             AuthenticationSchemes.HmacSha256,
             !string.IsNullOrEmpty(result.Failure?.Message)
                 ? $"{AuthenticationParameters.Error}=\"invalid_token\", {AuthenticationParameters.ErrorDescription}=\"{result.Failure.Message}\""
-                : null
-        ).ToString();
+                : null).ToString();
+    }
+
+    private async Task<string> ComputeContentHashAsync(Stream content)
+    {
+        Logger.LogDebug("Creating a new SHA-256 instance.");
+        using var sha256 = SHA256.Create();
+
+        Logger.LogDebug("Computing the SHA-256 hash of the content.");
+        return Convert.ToBase64String(await sha256.ComputeHashAsync(content));
+    }
+
+    private string ComputeHash(string value)
+    {
+        Logger.LogDebug("Constructing a new HMAC-SHA-256 instance with the secret '{Secret}'.", Options.Secret);
+        using var hmac = new HMACSHA256(Convert.FromBase64String(Options.Secret));
+
+        Logger.LogDebug("Computing the HMAC-SHA-256 hash of the value '{Value}'.", value);
+        return Convert.ToBase64String(hmac.ComputeHash(Encoding.ASCII.GetBytes(value)));
+    }
+
+    private string GetSignature(string signedHeaders, bool shouldIncludePort = true)
+    {
+        var builder = new StringBuilder();
+
+        var method = Request.Method.ToUpper();
+        Logger.LogDebug("Appending the method '{Method}' to the string to sign.", method);
+        builder.Append($"{method}\n");
+
+        var target = Context.Features.GetRequiredFeature<IHttpRequestFeature>().RawTarget;
+        Logger.LogDebug("Appending the path and query '{PathAndQuery}' to the string to sign.", target);
+        builder.Append($"{target}\n");
+
+        var signedHeadersValues = new List<string>();
+        Logger.LogDebug("Splitting the signed headers '{Headers}' on the delimiter ';'.", signedHeaders);
+        foreach (var signedHeader in signedHeaders.Split(';'))
+        {
+            Logger.LogDebug("Getting the signed header '{Header}' from the request headers.", signedHeader);
+            var signedHeadersValue = Request.Headers[signedHeader].ToString();
+            // TODO: Remove the should include port logic when this (https://github.com/Azure/azure-sdk-for-net/issues/41051) issue is closed.
+            if (!shouldIncludePort && signedHeader.Equals(HeaderNames.Host, StringComparison.OrdinalIgnoreCase) && signedHeadersValue.Contains(':'))
+            {
+                Logger.LogDebug("Removing the port from the host request header value.");
+                signedHeadersValue = signedHeadersValue[..signedHeadersValue.IndexOf(':')];
+            }
+            Logger.LogDebug("Adding the signed headers value '{Value}' to the signed headers values.", signedHeadersValue);
+            signedHeadersValues.Add(signedHeadersValue);
+        }
+        Logger.LogDebug("Appending the signed headers values '{Values}' to the string to sign.", signedHeadersValues);
+        builder.AppendJoin(';', signedHeadersValues);
+
+        return ComputeHash(builder.ToString());
     }
 
     private static class AuthenticationParameters


### PR DESCRIPTION
**Describe the change**
If you run the emulator via your IDE or `dotnet run`, the signature validation fails because the "host" includes a port (i.e. `localhost:5000`) on the emulator side but it does not include a port on the client side (since via the client SDK, Uri.Host does not return the port component). This causes the signature validation to fail.

This strips the port component from the Host header if it is present, as well as it breaks apart the several operations involved in computing a signature into separate variables to aid in debugging.

**Current behavior**
The signature validation fails if running via `dotnet run` or via the IDE.

**New behavior**
The signature validation passes if running via `dotnet run` or via the IDE.

**Additional context**
If you're open to it, I'd love to contribute more work to this project as it would be very valuable to my team!
