### PR TITLE
fix: configuration setting keys containing a slash character

### DIFF
--- a/src/AzureAppConfigurationEmulator/Program.cs
+++ b/src/AzureAppConfigurationEmulator/Program.cs
@@ -31,14 +31,14 @@ var app = builder.Build();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapGet("/kv/{key}", KeyValueHandler.Get).RequireAuthorization();
+app.MapGet("/kv/{**key}", KeyValueHandler.Get).RequireAuthorization();
 app.MapGet("/kv", KeyValueHandler.List).RequireAuthorization();
-app.MapPut("/kv/{key}", KeyValueHandler.Set).RequireAuthorization();
-app.MapDelete("/kv/{key}", KeyValueHandler.Delete).RequireAuthorization();
+app.MapPut("/kv/{**key}", KeyValueHandler.Set).RequireAuthorization();
+app.MapDelete("/kv/{**key}", KeyValueHandler.Delete).RequireAuthorization();
 app.MapGet("/keys", KeyHandler.List).RequireAuthorization();
 app.MapGet("/labels", LabelHandler.List).RequireAuthorization();
-app.MapPut("/locks/{key}", LockHandler.Lock).RequireAuthorization();
-app.MapDelete("/locks/{key}", LockHandler.Unlock).RequireAuthorization();
+app.MapPut("/locks/{**key}", LockHandler.Lock).RequireAuthorization();
+app.MapDelete("/locks/{**key}", LockHandler.Unlock).RequireAuthorization();
 
 app.InitializeDatabase();
 


### PR DESCRIPTION
This enables the use of prefixed keys that contain slashes, such as feature flags. Resolves #39, see it for details.