### PR TITLE
Update Postman instructions to support local debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const date = new Date().toUTCString();
 const contentHash = CryptoJS.SHA256(CryptoJS.enc.Utf8.parse(pm.request.body.toString())).toString(CryptoJS.enc.Base64);
 
 const signedHeaders = "x-ms-date;Host;x-ms-content-sha256";
-const stringToSign = `${pm.request.method}\n${pm.request.url.getPathWithQuery()}\n${date};${pm.request.url.getRemote()};${contentHash}`;
+const stringToSign = `${pm.request.method}\n${pm.request.url.getPathWithQuery()}\n${date};${pm.request.url.getHost()};${contentHash}`;
 const signature = CryptoJS.HmacSHA256(CryptoJS.enc.Utf8.parse(stringToSign), CryptoJS.enc.Base64.parse(secret)).toString(CryptoJS.enc.Base64);
 
 pm.request.headers.upsert(`x-ms-date: ${date}`);


### PR DESCRIPTION
**Describe the change**
This replaces `pm.request.url.getRemote()` with `pm.request.url.getHost()` in the Postman pre-request script. This matches the behavior fix in my other PR #38 to support local debugging, as the signed host header is sent as just `localhost` (rather than with the port) by the SDK. 

This change has been tested to be backwards compatible with App Config running on a standard port, including live Azure App Config.

**Current behavior**
The Postman pre-request script fails to authenticate when used with the emulator running directly on localhost on a non-standard port.

**New behavior**
The pre-request script authenticates successfully.

**Additional context**
N/A
