### PR TITLE
Add docker-compose file with better local debugging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,21 @@ Please note that Emulator for Azure App Configuration is unofficial and not endo
 ## Getting Started
 
 ```shell
-openssl req -x509 -out ./emulator.crt -keyout ./emulator.key -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost'
-docker build -f ./src/AzureAppConfigurationEmulator/Dockerfile -t azure-app-configuration-emulator .
-docker run -e ASPNETCORE_HTTP_PORTS=8080 -e ASPNETCORE_HTTPS_PORTS=8081 -p 8080:8080 -p 8081:8081 -v ./emulator.crt:/usr/local/share/azureappconfigurationemulator/emulator.crt:ro -v ./emulator.key:/usr/local/share/azureappconfigurationemulator/emulator.key:ro azure-app-configuration-emulator-data-potection-keys:/root/.aspnet/DataProtection-Keys azure-app-configuration-emulator
+docker-compose up -d
 ```
+
+(Leave off the `-d` to run in your current terminal instead of in background/detached mode.)
+
+### Local development
+
+1. Run `./keygen.sh` to generate the HTTPS keypair (Linux/macOS/WSL; Windows instructions TODO)
+2. Run `dotnet run` from the `src/AzureAppConfigurationEmulator` folder, or start the app from your IDE
 
 ## Authentication
 
 ### Postman
+
+Add the following code as a Pre-request Script in Postman to authenticate with the emulator:
 
 ```javascript
 const credential = "abcd";

--- a/container-entrypoint.sh
+++ b/container-entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e
+
+./keygen.sh && dotnet AzureAppConfigurationEmulator.dll

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  emulator:
+    build: 
+      context: .
+      dockerfile: ./src/AzureAppConfigurationEmulator/Dockerfile
+    ports:
+      - 8080:8080
+      - 8081:8081
+    volumes:
+      - data:/var/lib/azureappconfigurationemulator
+      - data-protection-keys:/root/.aspnet/DataProtection-Keys
+    environment:
+      - ASPNETCORE_HTTP_PORTS=8080
+      - ASPNETCORE_HTTPS_PORTS=8081
+      - ASPNETCORE_URLS=http://+:8080;https://+:8081
+      - DATABASE_PATH=/var/lib/azureappconfigurationemulator/emulator.db
+      - SSL_CERTIFICATE_KEY_PATH=/var/lib/azureappconfigurationemulator/emulator.key
+      - SSL_CERTIFICATE_CERT_PATH=/var/lib/azureappconfigurationemulator/emulator.crt
+volumes:
+  data:
+  data-protection-keys:

--- a/keygen.sh
+++ b/keygen.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+crt_file="${SSL_CERTIFICATE_CERT_PATH:-./src/AzureAppConfigurationEmulator/data/emulator.crt}"
+key_file="${SSL_CERTIFICATE_KEY_PATH:-./src/AzureAppConfigurationEmulator/data/emulator.key}"
+
+echo "Cert file: $crt_file"
+echo "Key file: $key_file"
+
+if [ -f "$crt_file" ] && [ -f "$key_file" ]; then
+    echo "Certificate and key already exist, skipping generation"
+    exit 0
+fi
+
+openssl req -x509 -out "$crt_file" -keyout "$key_file" -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost'
+
+echo "Certificate and key generated successfully"

--- a/src/AzureAppConfigurationEmulator/Dockerfile
+++ b/src/AzureAppConfigurationEmulator/Dockerfile
@@ -10,5 +10,13 @@ RUN dotnet publish "./src/AzureAppConfigurationEmulator/AzureAppConfigurationEmu
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
+
+RUN apt-get update && apt-get -y install openssh-client
+
 COPY --from=publish /app/publish .
-ENTRYPOINT ["dotnet", "AzureAppConfigurationEmulator.dll"]
+COPY "keygen.sh" .
+COPY "container-entrypoint.sh" .
+
+RUN chmod +x keygen.sh && chmod +x container-entrypoint.sh
+
+ENTRYPOINT ["./container-entrypoint.sh"]

--- a/src/AzureAppConfigurationEmulator/Extensions/HostingExtensions.cs
+++ b/src/AzureAppConfigurationEmulator/Extensions/HostingExtensions.cs
@@ -6,38 +6,11 @@ namespace AzureAppConfigurationEmulator.Extensions;
 
 public static class HostingExtensions
 {
-    public static string SslCertificatePath { get; } = Environment.OSVersion.Platform switch
-    {
-        PlatformID.Win32S => @"C:\ProgramData\Azure App Configuration Emulator\emulator.crt",
-        PlatformID.Win32Windows => @"C:\ProgramData\Azure App Configuration Emulator\emulator.crt",
-        PlatformID.Win32NT => @"C:\ProgramData\Azure App Configuration Emulator\emulator.crt",
-        PlatformID.WinCE => @"C:\ProgramData\Azure App Configuration Emulator\emulator.crt",
-        PlatformID.Unix => "/usr/local/share/azureappconfigurationemulator/emulator.crt",
-        PlatformID.MacOSX => "/usr/local/share/azureappconfigurationemulator/emulator.crt",
-        _ => throw new ArgumentOutOfRangeException()
-    };
+    public static string SslCertificatePath { get; } = Environment.GetEnvironmentVariable("SSL_CERTIFICATE_CERT_PATH") ?? "data/emulator.crt";
 
-    public static string SslCertificateKeyPath { get; } = Environment.OSVersion.Platform switch
-    {
-        PlatformID.Win32S => @"C:\ProgramData\Azure App Configuration Emulator\emulator.key",
-        PlatformID.Win32Windows => @"C:\ProgramData\Azure App Configuration Emulator\emulator.key",
-        PlatformID.Win32NT => @"C:\ProgramData\Azure App Configuration Emulator\emulator.key",
-        PlatformID.WinCE => @"C:\ProgramData\Azure App Configuration Emulator\emulator.key",
-        PlatformID.Unix => "/usr/local/share/azureappconfigurationemulator/emulator.key",
-        PlatformID.MacOSX => "/usr/local/share/azureappconfigurationemulator/emulator.key",
-        _ => throw new ArgumentOutOfRangeException()
-    };
+    public static string SslCertificateKeyPath { get; } = Environment.GetEnvironmentVariable("SSL_CERTIFICATE_KEY_PATH") ?? "data/emulator.key";
 
-    public static string DatabasePath { get; } = Environment.OSVersion.Platform switch
-    {
-        PlatformID.Win32S => @"C:\ProgramData\Azure App Configuration Emulator\emulator.db",
-        PlatformID.Win32Windows => @"C:\ProgramData\Azure App Configuration Emulator\emulator.db",
-        PlatformID.Win32NT => @"C:\ProgramData\Azure App Configuration Emulator\emulator.db",
-        PlatformID.WinCE => @"C:\ProgramData\Azure App Configuration Emulator\emulator.db",
-        PlatformID.Unix => "/var/lib/azureappconfigurationemulator/emulator.db",
-        PlatformID.MacOSX => "/var/lib/azureappconfigurationemulator/emulator.db",
-        _ => throw new ArgumentOutOfRangeException()
-    };
+    public static string DatabasePath { get; } = Environment.GetEnvironmentVariable("DATABASE_PATH") ?? "data/emulator.db";
 
     public static IWebHostBuilder ConfigureKestrel(this IWebHostBuilder builder)
     {

--- a/src/AzureAppConfigurationEmulator/data/.gitignore
+++ b/src/AzureAppConfigurationEmulator/data/.gitignore
@@ -1,0 +1,1 @@
+emulator.*


### PR DESCRIPTION
**Describe the change**
This adds a docker-compose.yml file and updates the README to simplify running the app to just `docker-compose up -d`. This should greatly simplify the experience for new users running the emulator. The compose file also uses named volumes for easy persistence and access from the host for the keypair and database files.

In order to better support local debugging without having to have access to system folders, this uses an environment variable when running in Docker for the database and cert/key files, but defaults to a "data" folder within the repo so that the IDE/CLI does not need special permissions to /var (on macOS/Linux).

Additionally, the openssl command has been moved into `keygen.sh` which can be run locally for local development, but is also run by the container and is aware of those Docker Compose environment variables, falling back to the local data folder.

**Current behavior**
The instructions to start up the emulator are complex and are not easily repeatable.

**New behavior**
The startup of the emulator is easy with `docker-compose up`

**Additional context**
Updates README, adds keygen.sh file for easy key generation.
