### PR TITLE
refactor: align dialog implementation with others

### DIFF
--- a/src/AzureAppConfigurationEmulator/Components/App.razor
+++ b/src/AzureAppConfigurationEmulator/Components/App.razor
@@ -8,11 +8,11 @@
     <link rel="stylesheet" href="app.css"/>
     @* <link rel="stylesheet" href="AzureAppConfigurationEmulator.styles.css"/> *@
     <link rel="icon" type="image/png" href="favicon.png"/>
-    <HeadOutlet/>
+    <HeadOutlet @rendermode="@InteractiveServer"/>
 </head>
 
 <body class="text-base bg-white text-mine-shaft dark:bg-cod-grey dark:text-desert-storm">
-<Routes/>
+<Routes @rendermode="@InteractiveServer"/>
 <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/src/AzureAppConfigurationEmulator/Components/AzureDialog.razor
+++ b/src/AzureAppConfigurationEmulator/Components/AzureDialog.razor
@@ -1,27 +1,38 @@
-<CascadingValue Value="this">
-    <dialog class="mr-0 max-w-full h-full max-h-full bg-white text-mine-shaft w-[585px] dark:bg-cod-grey dark:text-desert-storm" id="@Id">
-        <div class="flex flex-col w-full h-full">
-            <header class="py-2 px-5">
-                @HeaderContent
-            </header>
+@using AzureAppConfigurationEmulator.Services
 
-            <div class="flex-1 p-5">
-                @ChildContent
-            </div>
+<dialog class="mr-0 max-w-full h-full max-h-full bg-white text-mine-shaft w-[585px] dark:bg-cod-grey dark:text-desert-storm" @ref="@ElementReference">
+    <div class="flex flex-col w-full h-full">
+        <header class="py-2 px-5">
+            @HeaderContent
+        </header>
 
-            <footer class="p-5 border-t border-t-alto dark:border-t-masala">
-                @FooterContent
-            </footer>
+        <div class="flex-1 p-5">
+            @ChildContent
         </div>
-    </dialog>
-</CascadingValue>
+
+        <footer class="p-5 border-t border-t-alto dark:border-t-masala">
+            @FooterContent
+        </footer>
+    </div>
+</dialog>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    [CascadingParameter] public IDialogReference DialogReference { get; set; } = null!;
 
     [Parameter] public RenderFragment? FooterContent { get; set; }
 
     [Parameter] public RenderFragment? HeaderContent { get; set; }
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
+    private ElementReference ElementReference { get; set; }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            DialogReference.TrySetElement(ElementReference);
+        }
+    }
+
 }

--- a/src/AzureAppConfigurationEmulator/Components/AzureDialogHeader.razor
+++ b/src/AzureAppConfigurationEmulator/Components/AzureDialogHeader.razor
@@ -1,5 +1,4 @@
 @inject IDialogService DialogService
-@rendermode InteractiveServer
 @using AzureAppConfigurationEmulator.Services
 
 <div class="flex flex-row">
@@ -16,14 +15,14 @@
 </div>
 
 @code {
-    [CascadingParameter] public required AzureDialog AzureDialog { get; set; }
+    [CascadingParameter] public IDialogReference DialogReference { get; set; } = null!;
 
     [Parameter] public string? Subtitle { get; set; }
 
-    [EditorRequired, Parameter] public required string Title { get; set; }
+    [EditorRequired, Parameter] public string Title { get; set; } = null!;
 
     private async Task HandleCloseClick(MouseEventArgs args)
     {
-        await DialogService.CloseAsync(AzureDialog.Id);
+        await DialogService.Close(DialogReference);
     }
 }

--- a/src/AzureAppConfigurationEmulator/Components/AzureDialogProvider.razor
+++ b/src/AzureAppConfigurationEmulator/Components/AzureDialogProvider.razor
@@ -1,0 +1,71 @@
+@implements IAsyncDisposable
+@implements IDisposable
+@inject IDialogService DialogService
+@inject IJSRuntime JS
+@using AzureAppConfigurationEmulator.Services
+
+@foreach (var reference in References)
+{
+    <CascadingValue Value="@reference">
+        <DynamicComponent Parameters="@reference.Parameters" Type="@reference.Type"/>
+    </CascadingValue>
+}
+
+@code {
+    private IJSObjectReference? Module { get; set; }
+
+    private ICollection<IDialogReference> References { get; } = [];
+
+    public void Dispose()
+    {
+        DialogService.OnDialogClosed -= HandleDialogClosed;
+
+        DialogService.OnDialogShown -= HandleDialogShown;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Module is not null)
+        {
+            await Module.DisposeAsync();
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            Module = await JS.InvokeAsync<IJSObjectReference>("import", "./Components/AzureDialogProvider.razor.js");
+        }
+    }
+
+    protected override void OnInitialized()
+    {
+        DialogService.OnDialogClosed += HandleDialogClosed;
+
+        DialogService.OnDialogShown += HandleDialogShown;
+    }
+
+    private async Task HandleDialogClosed(IDialogReference reference, IDialogResult? result)
+    {
+        if (Module is not null)
+        {
+            await Module.InvokeVoidAsync("close", await reference.Element, result);
+        }
+
+        References.Remove(reference);
+        StateHasChanged();
+    }
+
+    private async Task HandleDialogShown(IDialogReference reference)
+    {
+        References.Add(reference);
+        StateHasChanged();
+
+        if (Module is not null)
+        {
+            await Module.InvokeVoidAsync("show", await reference.Element);
+        }
+    }
+
+}

--- a/src/AzureAppConfigurationEmulator/Components/AzureDialogProvider.razor.js
+++ b/src/AzureAppConfigurationEmulator/Components/AzureDialogProvider.razor.js
@@ -1,0 +1,7 @@
+export function close(element, result) {
+    element?.close(result);
+}
+
+export function show(element) {
+    element?.showModal();
+}

--- a/src/AzureAppConfigurationEmulator/Components/ConfigurationSettingCreateDialog.razor
+++ b/src/AzureAppConfigurationEmulator/Components/ConfigurationSettingCreateDialog.razor
@@ -1,11 +1,9 @@
 @inject IConfigurationSettingFactory ConfigurationSettingFactory
 @inject IDialogService DialogService
-@rendermode InteractiveServer
-@using AzureAppConfigurationEmulator.Entities
 @using AzureAppConfigurationEmulator.Factories
 @using AzureAppConfigurationEmulator.Services
 
-<AzureDialog Id="@Id">
+<AzureDialog>
     <HeaderContent>
         <AzureDialogHeader Subtitle="Create a new key-value." Title="Create"/>
     </HeaderContent>
@@ -27,9 +25,7 @@
 </AzureDialog>
 
 @code {
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
-    
-    [Parameter] public EventCallback<ConfigurationSetting> OnCreate { get; set; }
+    [CascadingParameter] public IDialogReference DialogReference { get; set; } = null!;
 
     private bool IsDisabled => string.IsNullOrEmpty(Input.Key);
 
@@ -39,9 +35,9 @@
     {
         if (!string.IsNullOrEmpty(Input.Key))
         {
-            await OnCreate.InvokeAsync(ConfigurationSettingFactory.Create(Input.Key, Input.Label, Input.ContentType, Input.Value));
+            var setting = ConfigurationSettingFactory.Create(Input.Key, Input.Label, Input.ContentType, Input.Value);
 
-            await DialogService.CloseAsync(Id);
+            await DialogService.Close(DialogReference, new DialogResult(setting));
         }
     }
 

--- a/src/AzureAppConfigurationEmulator/Components/ConfigurationSettingEditDialog.razor
+++ b/src/AzureAppConfigurationEmulator/Components/ConfigurationSettingEditDialog.razor
@@ -1,11 +1,10 @@
 @inject IDialogService DialogService
-@rendermode InteractiveServer
 @using System.Security.Cryptography
 @using System.Text
 @using AzureAppConfigurationEmulator.Entities
 @using AzureAppConfigurationEmulator.Services
 
-<AzureDialog Id="@Id">
+<AzureDialog>
     <HeaderContent>
         <AzureDialogHeader Subtitle="Edit the key-value." Title="Edit"/>
     </HeaderContent>
@@ -29,9 +28,7 @@
 @code {
     [EditorRequired, Parameter] public ConfigurationSetting ConfigurationSetting { get; set; } = null!;
 
-    [Parameter] public string Id { get; set; } = Guid.NewGuid().ToString();
-
-    [Parameter] public EventCallback<ConfigurationSetting> OnEdit { get; set; }
+    [CascadingParameter] public IDialogReference DialogReference { get; set; } = null!;
 
     private InputModel Input { get; } = new();
 
@@ -54,15 +51,15 @@
     {
         var date = DateTimeOffset.UtcNow;
 
-        await OnEdit.InvokeAsync(ConfigurationSetting with
+        var setting = ConfigurationSetting with
         {
             Etag = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(date.UtcDateTime.ToString("yyyy-MM-dd HH:mm:ss")))),
             ContentType = Input.ContentType,
             Value = Input.Value,
             LastModified = date
-        });
+        };
 
-        await DialogService.CloseAsync(Id);
+        await DialogService.Close(DialogReference, new DialogResult(setting));
     }
 
     private class InputModel

--- a/src/AzureAppConfigurationEmulator/Components/Layout/MainLayout.razor
+++ b/src/AzureAppConfigurationEmulator/Components/Layout/MainLayout.razor
@@ -36,3 +36,5 @@
     <a href="" class="reload">Reload</a>
     <a class="absolute top-2 right-3 cursor-pointer dismiss">🗙</a>
 </div>
+
+<AzureDialogProvider/>

--- a/src/AzureAppConfigurationEmulator/Components/Pages/AccessKeys.razor
+++ b/src/AzureAppConfigurationEmulator/Components/Pages/AccessKeys.razor
@@ -1,7 +1,6 @@
 @inject IOptionsMonitor<HmacOptions> HmacOptionsMonitor
 @inject IServer Server
 @page "/keys"
-@rendermode InteractiveServer
 @using AzureAppConfigurationEmulator.Authentication
 @using Microsoft.AspNetCore.Hosting.Server
 @using Microsoft.AspNetCore.Hosting.Server.Features

--- a/src/AzureAppConfigurationEmulator/Components/Pages/ConfigurationExplorer.razor
+++ b/src/AzureAppConfigurationEmulator/Components/Pages/ConfigurationExplorer.razor
@@ -2,7 +2,6 @@
 @inject IConfigurationSettingRepository ConfigurationSettingRepository
 @inject IDialogService DialogService
 @page "/kvs"
-@rendermode InteractiveServer
 @using AzureAppConfigurationEmulator.Entities
 @using AzureAppConfigurationEmulator.Repositories
 @using AzureAppConfigurationEmulator.Services
@@ -48,13 +47,6 @@
     </div>
 </div>
 
-<ConfigurationSettingCreateDialog Id="@nameof(ConfigurationSettingCreateDialog)" OnCreate="@HandleConfigurationSettingCreate"/>
-
-@if (SelectedConfigurationSettings is { Count: 1 })
-{
-    <ConfigurationSettingEditDialog ConfigurationSetting="@SelectedConfigurationSettings.Single()" Id="@nameof(ConfigurationSettingEditDialog)" OnEdit="@HandleConfigurationSettingEdit"/>
-}
-
 @code {
     private ICollection<ConfigurationSetting> ConfigurationSettings { get; } = [];
 
@@ -78,34 +70,42 @@
         }
     }
 
-    private async Task HandleConfigurationSettingCreate(ConfigurationSetting setting)
-    {
-        await ConfigurationSettingRepository.Add(setting);
-        
-        ConfigurationSettings.Add(setting);
-        StateHasChanged();
-    }
-
-    private async Task HandleConfigurationSettingEdit(ConfigurationSetting setting)
-    {
-        await ConfigurationSettingRepository.Update(setting);
-
-        ConfigurationSettings.Remove(SelectedConfigurationSettings.Single());
-        ConfigurationSettings.Add(setting);
-        StateHasChanged();
-
-        SelectedConfigurationSettings.Clear();
-        StateHasChanged();
-    }
-
     private async Task HandleCreateClick(MouseEventArgs args)
     {
-        await DialogService.ShowAsync(nameof(ConfigurationSettingCreateDialog));
+        var reference = await DialogService.Show<ConfigurationSettingCreateDialog>();
+        var result = await reference.Result;
+        if (result is { Data: ConfigurationSetting setting })
+        {
+            await ConfigurationSettingRepository.Add(setting);
+
+            ConfigurationSettings.Add(setting);
+            StateHasChanged();
+        }
     }
 
     private async Task HandleEditClick(MouseEventArgs args)
     {
-        await DialogService.ShowAsync(nameof(ConfigurationSettingEditDialog));
+        var parameters = new Dictionary<string, object?>
+        {
+            {
+                nameof(ConfigurationSettingEditDialog.ConfigurationSetting),
+                SelectedConfigurationSettings.Single()
+            }
+        };
+
+        var reference = await DialogService.Show<ConfigurationSettingEditDialog>(parameters);
+        var result = await reference.Result;
+        if (result is { Data: ConfigurationSetting setting })
+        {
+            await ConfigurationSettingRepository.Update(setting);
+
+            ConfigurationSettings.Remove(SelectedConfigurationSettings.Single());
+            ConfigurationSettings.Add(setting);
+            StateHasChanged();
+
+            SelectedConfigurationSettings.Clear();
+            StateHasChanged();
+        }
     }
 
     private async Task HandleDeleteClick(MouseEventArgs args)

--- a/src/AzureAppConfigurationEmulator/Components/Pages/FeatureManager.razor
+++ b/src/AzureAppConfigurationEmulator/Components/Pages/FeatureManager.razor
@@ -1,7 +1,6 @@
 @attribute [StreamRendering]
 @inject IConfigurationSettingRepository ConfigurationSettingRepository
 @page "/ff"
-@rendermode InteractiveServer
 @using AzureAppConfigurationEmulator.Entities
 @using AzureAppConfigurationEmulator.Repositories
 

--- a/src/AzureAppConfigurationEmulator/Services/IDialogService.cs
+++ b/src/AzureAppConfigurationEmulator/Services/IDialogService.cs
@@ -1,9 +1,86 @@
+using Microsoft.AspNetCore.Components;
+
 namespace AzureAppConfigurationEmulator.Services;
 
+/// <summary>
+/// The reference to the dialog that is shown.
+/// </summary>
+public interface IDialogReference
+{
+    /// <summary>
+    /// Gets a task that completes with the <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog">element</see> that is rendered.
+    /// </summary>
+    public Task<ElementReference> Element { get; }
+
+    /// <summary>
+    /// Gets the parameters to pass to the component.
+    /// </summary>
+    public IDictionary<string, object?>? Parameters { get; }
+
+    /// <summary>
+    /// Gets a task that completes with the result that is returned when the dialog is closed.
+    /// </summary>
+    public Task<IDialogResult?> Result { get; }
+
+    /// <summary>
+    /// Gets the type of the component that represents the dialog.
+    /// </summary>
+    public Type Type { get; }
+
+    /// <summary>
+    /// Tries to set the <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog">element</see> that is rendered.
+    /// </summary>
+    /// <param name="element">The <see href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog">element</see> that is rendered.</param>
+    /// <returns>True if the element was set; otherwise, false.</returns>
+    public bool TrySetElement(ElementReference element);
+
+    /// <summary>
+    /// Tries to set the result that is returned when the dialog is closed.
+    /// </summary>
+    /// <param name="result">The result that is returned when the dialog is closed.</param>
+    /// <returns>True if the result was set; otherwise, false.</returns>
+    public bool TrySetResult(IDialogResult? result = null);
+}
+
+/// <summary>
+/// The result that is returned when the dialog is closed.
+/// </summary>
+public interface IDialogResult
+{
+    /// <summary>
+    /// Gets the data for the result.
+    /// </summary>
+    public object? Data { get; }
+}
+
+/// <summary>
+/// The service that shows and closes dialogs.
+/// </summary>
 public interface IDialogService
 {
-    public Task CloseAsync(string id);
-    public Task CloseAsync<TResult>(string id, TResult result);
-    
-    public Task ShowAsync(string id);
+    /// <summary>
+    /// Invoked when a dialog is closed with the refernece to the dialog and the result that is returned when the dialog is closed.
+    /// </summary>
+    public event Func<IDialogReference, IDialogResult?, Task>? OnDialogClosed;
+
+    /// <summary>
+    /// Invoked when a dialog is shown with the reference to the dialog.
+    /// </summary>
+    public event Func<IDialogReference, Task>? OnDialogShown;
+
+    /// <summary>
+    /// Closes the dialog that is referred to by the <see cref="reference"/>.
+    /// </summary>
+    /// <param name="reference">The reference to the dialog that is shown.</param>
+    /// <param name="result">The result that is returned when the dialog is closed.</param>
+    /// <returns>A task that completes when the dialog was closed.</returns>
+    public Task Close(IDialogReference reference, IDialogResult? result = null);
+
+    /// <summary>
+    /// Shows the dialog that is represented by the <see cref="TComponent"/>.
+    /// </summary>
+    /// <param name="parameters">The parameters to pass to the <see cref="TComponent"/>.</param>
+    /// <typeparam name="TComponent">The type of the component that represents the dialog.</typeparam>
+    /// <returns>A task that completes with the reference to the dialog that was shown.</returns>
+    public Task<IDialogReference> Show<TComponent>(IDictionary<string, object?>? parameters = null);
 }

--- a/src/AzureAppConfigurationEmulator/wwwroot/scripts/dialog.js
+++ b/src/AzureAppConfigurationEmulator/wwwroot/scripts/dialog.js
@@ -1,7 +1,0 @@
-export function close(id, result) {
-    document.getElementById(id)?.close(result);
-}
-
-export function show(id) {
-    document.getElementById(id)?.showModal();
-}


### PR DESCRIPTION
**Describe the change**
This change aligns the dialog implementation with others for example [Fluent UI Blazor](https://www.fluentui-blazor.net/dialog) and [MudBlazor](https://mudblazor.com/components/dialog).

**Current behavior**
The dialog implementation is bespoke and not very reusable.

**New behavior**
The dialog implementation is aligned with others and is more reusable.

**Additional context**
The render mode of the [entire application](https://learn.microsoft.com/en-us/aspnet/core/blazor/components/render-modes#apply-a-render-mode-to-the-entire-app) has been changed to `InteractiveServer`.
