### PR TITLE
refactor: add key value pair json encoder

### DIFF
--- a/src/AzureAppConfigurationEmulator/Common/IKeyValuePairJsonEncoder.cs
+++ b/src/AzureAppConfigurationEmulator/Common/IKeyValuePairJsonEncoder.cs
@@ -1,0 +1,11 @@
+using System.Text.Json;
+
+namespace AzureAppConfigurationEmulator.Common;
+
+public interface IKeyValuePairJsonEncoder
+{
+    JsonDocument Encode(
+        IEnumerable<KeyValuePair<string, string?>> pairs,
+        string? prefix = null,
+        string? separator = null);
+}

--- a/src/AzureAppConfigurationEmulator/Common/KeyValuePairJsonEncoder.cs
+++ b/src/AzureAppConfigurationEmulator/Common/KeyValuePairJsonEncoder.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace AzureAppConfigurationEmulator.Common;
+
+public class KeyValuePairJsonEncoder : IKeyValuePairJsonEncoder
+{
+    public JsonDocument Encode(
+        IEnumerable<KeyValuePair<string, string?>> pairs,
+        string? prefix = null,
+        string? separator = null)
+    {
+        JsonNode root = new JsonObject();
+
+        foreach (var (key, value) in pairs)
+        {
+            var keys = key.Split(separator).ToList();
+
+            if (!string.IsNullOrEmpty(prefix))
+            {
+                if (keys[0] == prefix)
+                {
+                    keys.RemoveAt(0);
+                }
+                else if (keys[0].StartsWith(prefix))
+                {
+                    keys[0] = keys[0][prefix.Length..];
+                }
+            }
+
+            var current = root;
+
+            for (var i = 0; i < keys.Count; i++)
+            {
+                if (int.TryParse(keys[i], out var index))
+                {
+                    if (i == keys.Count - 1)
+                    {
+                        current.AsArray().Insert(index, value);
+
+                        break;
+                    }
+
+                    if (current.AsArray().ElementAtOrDefault(index) is not { } next)
+                    {
+                        if (int.TryParse(keys[i + 1], out _))
+                        {
+                            next = new JsonArray();
+                        }
+                        else
+                        {
+                            next = new JsonObject();
+                        }
+
+                        current.AsArray().Insert(index, next);
+                    }
+
+                    current = next;
+                }
+                else
+                {
+                    if (i == keys.Count - 1)
+                    {
+                        current[keys[i]] = value;
+                        
+                        break;
+                    }
+
+                    if (current[keys[i]] is not { } next)
+                    {
+                        if (int.TryParse(keys[i + 1], out _))
+                        {
+                            next = new JsonArray();
+                        }
+                        else
+                        {
+                            next = new JsonObject();
+                        }
+
+                        current[keys[i]] = next;
+                    }
+
+                    current = next;
+                }
+            }
+        }
+
+        return root.Deserialize<JsonDocument>()!;
+    }
+}

--- a/src/AzureAppConfigurationEmulator/Program.cs
+++ b/src/AzureAppConfigurationEmulator/Program.cs
@@ -87,6 +87,7 @@ builder.Services.AddSingleton<IDbConnectionFactory, SqliteDbConnectionFactory>()
 builder.Services.AddSingleton<IDbParameterFactory, SqliteDbParameterFactory>();
 builder.Services.AddSingleton<IEventGridEventFactory, HttpContextEventGridEventFactory>();
 builder.Services.AddSingleton<IKeyValuePairJsonDecoder, KeyValuePairJsonDecoder>();
+builder.Services.AddSingleton<IKeyValuePairJsonEncoder, KeyValuePairJsonEncoder>();
 
 var app = builder.Build();
 

--- a/tests/AzureAppConfigurationEmulator.Tests/Common/KeyValuePairJsonDecoderTests.cs
+++ b/tests/AzureAppConfigurationEmulator.Tests/Common/KeyValuePairJsonDecoderTests.cs
@@ -15,7 +15,7 @@ public class KeyValuePairJsonDecoderTests
     }
 
     [TestCaseSource(nameof(Decode_KeyValuePairs_DocumentAndPrefixAndSeparator_TestCases))]
-    public void Decode_KeyValuePairs_DocumentAndPrefixAndSeparator(string json, string? prefix, string? separator, IDictionary<string, string?> expected)
+    public void Decode_KeyValuePairs_DocumentAndPrefixAndSeparator(string json, string? prefix, string? separator, IEnumerable<KeyValuePair<string, string?>> expected)
     {
         // Arrange
         using var document = JsonDocument.Parse(json);
@@ -24,7 +24,7 @@ public class KeyValuePairJsonDecoderTests
         var settings = Decoder.Decode(document, prefix, separator);
 
         // Assert
-        Assert.That(settings.ToDictionary(), Is.EqualTo(expected));
+        Assert.That(settings, Is.EqualTo(expected));
     }
 
     // ReSharper disable once InconsistentNaming

--- a/tests/AzureAppConfigurationEmulator.Tests/Common/KeyValuePairJsonEncoderTests.cs
+++ b/tests/AzureAppConfigurationEmulator.Tests/Common/KeyValuePairJsonEncoderTests.cs
@@ -1,0 +1,101 @@
+using System.Text.Json;
+using AzureAppConfigurationEmulator.Common;
+using NUnit.Framework;
+
+namespace AzureAppConfigurationEmulator.Tests.Common;
+
+public class KeyValuePairJsonEncoderTests
+{
+    private KeyValuePairJsonEncoder Encoder { get; set; }
+
+    [SetUp]
+    public void SetUp()
+    {
+        Encoder = new KeyValuePairJsonEncoder();
+    }
+
+    [TestCaseSource(nameof(Encode_Document_KeyValuePairsAndPrefixAndSeparator_TestCases))]
+    public void Encode_Document_KeyValuePairsAndPrefixAndSeparator(IEnumerable<KeyValuePair<string, string?>> pairs, string? prefix, string? separator, string expected)
+    {
+        // Act
+        using var document = Encoder.Encode(pairs, prefix, separator);
+
+        // Assert
+        Assert.That(JsonSerializer.Serialize(document), Is.EqualTo(expected));
+    }
+
+    // ReSharper disable once InconsistentNaming
+    private static object[] Encode_Document_KeyValuePairsAndPrefixAndSeparator_TestCases =
+    [
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestKey", "TestValue" } },
+            null,
+            null,
+            "{\"TestKey\":\"TestValue\"}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestPrefixTestKey", "TestValue" } },
+            "TestPrefix",
+            null,
+            "{\"TestKey\":\"TestValue\"}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestKey", "TestValue" } },
+            null,
+            ".",
+            "{\"TestKey\":\"TestValue\"}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestPrefix.TestKey", "TestValue" } },
+            "TestPrefix",
+            ".",
+            "{\"TestKey\":\"TestValue\"}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestOuterKey.TestInnerKey", "TestValue" } },
+            null,
+            ".",
+            "{\"TestOuterKey\":{\"TestInnerKey\":\"TestValue\"}}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestPrefix.TestOuterKey.TestInnerKey", "TestValue" } },
+            "TestPrefix",
+            ".",
+            "{\"TestOuterKey\":{\"TestInnerKey\":\"TestValue\"}}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestKey.0", "TestValue" } },
+            null,
+            ".",
+            "{\"TestKey\":[\"TestValue\"]}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestPrefix.TestKey.0", "TestValue" } },
+            "TestPrefix",
+            ".",
+            "{\"TestKey\":[\"TestValue\"]}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestOuterKey.0.TestInnerKey", "TestValue" } },
+            null,
+            ".",
+            "{\"TestOuterKey\":[{\"TestInnerKey\":\"TestValue\"}]}"
+        },
+        new object?[]
+        {
+            new Dictionary<string, string?> { { "TestPrefix.TestOuterKey.0.TestInnerKey", "TestValue" } },
+            "TestPrefix",
+            ".",
+            "{\"TestOuterKey\":[{\"TestInnerKey\":\"TestValue\"}]}"
+        }
+    ];
+}


### PR DESCRIPTION
**Describe the change**
This change adds an encoder that encodes an enumerable of key value pairs to a JSON document.

**Additional context**
This change is in preparation for upcoming functionality that will be added to the import/export page.