### PR TITLE
refactor: align microsoft entra id app settings with managed identity

### DIFF
--- a/src/AzureAppConfigurationEmulator/appsettings.json
+++ b/src/AzureAppConfigurationEmulator/appsettings.json
@@ -6,7 +6,7 @@
         "Secret": "c2VjcmV0"
       },
       "MicrosoftEntraId": {
-        "ValidAudience": "https://azconfig.io"
+        "ValidAudience": "https://appconfig.azure.com"
       }
     }
   },


### PR DESCRIPTION
**Describe the change**
This change aligns the Microsoft Entra ID app settings with Managed Identity for ease of use.

**Current behavior**
The `ValidAudience` app setting should be overridden to match the audience for access tokens.

**New behavior**
The `ValidAudience` app setting does not need to be overridden when using Managed Identity.