### PR TITLE
docs: Add Entra ID integration example to Testcontainers section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ services:
     entrypoint: /bin/sh -c "update-ca-certificates && dotnet ConsoleApplication.dll"
     environment:
       - Endpoints__AzureAppConfiguration=https://azure-app-configuration-emulator:8081
+      - IDENTITY_ENDPOINT=http://assumed-identity:80/metadata/identity/oauth2/token
+      - IDENTITY_HEADER=dummy
     volumes:
       - ./emulator.crt:/usr/local/share/ca-certificates/emulator.crt:ro
 ```
@@ -316,7 +318,7 @@ services:
 The emulator integrates with [Testcontainers](https://testcontainers.org) to ease the integration testing of applications that use Azure App Configuration.
 
 ```csharp
-var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator:1.0")
+var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator")
     .WithPortBinding(8080, true)
     .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
     .Build();
@@ -346,65 +348,57 @@ var response = await client.GetConfigurationSettingAsync(nameof(ConfigurationSet
 
 ### Authentication
 
-The default authentication scheme is HMAC.
-
 #### HMAC
 
 ```csharp
+var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator")
+    .WithPortBinding(8080, true)
+    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
+    .Build();
+
+await container.StartAsync();
+
 var client = new ConfigurationClient($"Endpoint={new UriBuilder(Uri.UriSchemeHttp, container.Hostname, container.GetMappedPublicPort(8080))};Id=abcd;Secret=c2VjcmV0");
 ```
 
 #### Microsoft Entra ID
 
-The emulator may be configured to authenticate tokens issued by actual Entra ID by setting the metadata address, valid issuer and valid audience using the environment variables `Authentication__Schemes__MicrosoftEntraId__MetadataAddress`, `Authentication__Schemes__MicrosoftEntraId__ValidIssuer` and `Authentication__Schemes__MicrosoftEntraId__ValidAudience` respectively.
-
-```csharp
-var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator:1.0")
-    .WithPortBinding(8080, true)
-    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
-    .WithEnvironment(
-        "Authentication__Schemes__MicrosoftEntraId__MetadataAddress",
-        $"https://login.microsoftonline.com/{tenantId}/.well-known/openid-configuration")
-    .WithEnvironment(
-        "Authentication__Schemes__MicrosoftEntraId__ValidIssuer",
-        $"https://sts.windows.net/{tenantId}/")
-    .WithEnvironment(
-        "Authentication__Schemes__MicrosoftEntraId__ValidAudience",
-        "https://azconfig.io")
-    .Build();
-
-var credential = new DefaultAzureCredential();
-var client = new ConfigurationClient(endpoint, credential);
-```
-
-Alternatively, [Assumed Identity](https://github.com/nagyesta/assumed-identity) may be used to simulate how Azure Instance Metadata Service (IMDS) handles Managed Identity tokens, enabling real Entra ID integration without an actual Azure environment.
-
 ```csharp
 var network = new NetworkBuilder()
+    .WithName(Guid.NewGuid().ToString())
     .Build();
 
-var assumedIdentityContainer = new ContainerBuilder("nagyesta/assumed-identity")
-    .WithNetwork(network)
-    .WithNetworkAliases("assumed-identity")
-    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Started AssumedIdentity"))
-    .Build();
-
-var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator:1.0")
-    .WithPortBinding(8080, true)
-    .WithNetwork(network)
-    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
-    .WithEnvironment(
-        "Authentication__Schemes__MicrosoftEntraId__MetadataAddress",
-        "http://assumed-identity/metadata/identity/.well-known/openid-configuration")
-    .WithEnvironment(
-        "Authentication__Schemes__MicrosoftEntraId__RequireHttpsMetadata",
-        "false")
-    .Build();
+var containers = new List<IContainer>
+{
+    new ContainerBuilder("nagyesta/assumed-identity")
+        .WithNetwork(network)
+        .WithNetworkAliases("assumed-identity")
+        .WithPortBinding(80, true)
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Running on all addresses"))
+        .Build(),
+    new ContainerBuilder("tnc1997/azure-app-configuration-emulator")
+        .WithEnvironment("ASPNETCORE_HTTP_PORTS", "8080")
+        .WithEnvironment("ASPNETCORE_HTTPS_PORTS", "8081")
+        .WithEnvironment("Authentication__Schemes__MicrosoftEntraId__MetadataAddress", "http://assumed-identity/metadata/identity/.well-known/openid-configuration")
+        .WithEnvironment("Authentication__Schemes__MicrosoftEntraId__RequireHttpsMetadata", "false")
+        .WithEnvironment("Kestrel__Certificates__Default__Path", "/usr/local/share/azureappconfigurationemulator/emulator.crt")
+        .WithEnvironment("Kestrel__Certificates__Default__KeyPath", "/usr/local/share/azureappconfigurationemulator/emulator.key")
+        .WithNetwork(network)
+        .WithPortBinding(8080, true)
+        .WithPortBinding(8081, true)
+        .WithResourceMapping(FilePath.Of("./emulator.crt"), FilePath.Of("/usr/local/share/azureappconfigurationemulator/emulator.crt"))
+        .WithResourceMapping(FilePath.Of("./emulator.key"), FilePath.Of("/usr/local/share/azureappconfigurationemulator/emulator.key"))
+        .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
+        .Build()
+};
 
 await network.CreateAsync();
-await assumedIdentityContainer.StartAsync();
-await container.StartAsync();
+await Task.WhenAll(containers[0].StartAsync(), containers[1].StartAsync());
 
+Environment.SetEnvironmentVariable("IDENTITY_ENDPOINT", $"http://{containers[0].Hostname}:{containers[0].GetMappedPublicPort(80)}/metadata/identity/oauth2/token");
+Environment.SetEnvironmentVariable("IDENTITY_HEADER", "dummy");
+
+var endpoint = $"https://{containers[1].Hostname}:{containers[1].GetMappedPublicPort(8081)}";
 var credential = new ManagedIdentityCredential();
-var client = new ConfigurationClient(new Uri($"http://{container.Hostname}:{container.GetMappedPublicPort(8080)}"), credential);
+var client = new ConfigurationClient(new Uri(endpoint), credential);
 ```

--- a/README.md
+++ b/README.md
@@ -316,8 +316,7 @@ services:
 The emulator integrates with [Testcontainers](https://testcontainers.org) to ease the integration testing of applications that use Azure App Configuration.
 
 ```csharp
-var container = new ContainerBuilder()
-    .WithImage("tnc1997/azure-app-configuration-emulator:1.0")
+var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator:1.0")
     .WithPortBinding(8080, true)
     .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
     .Build();
@@ -343,4 +342,69 @@ var client = new ConfigurationClient(container.GetConnectionString());
 await client.SetConfigurationSettingAsync(nameof(ConfigurationSetting.Key), nameof(ConfigurationSetting.Value));
 
 var response = await client.GetConfigurationSettingAsync(nameof(ConfigurationSetting.Key));
+```
+
+### Authentication
+
+The default authentication scheme is HMAC.
+
+#### HMAC
+
+```csharp
+var client = new ConfigurationClient($"Endpoint={new UriBuilder(Uri.UriSchemeHttp, container.Hostname, container.GetMappedPublicPort(8080))};Id=abcd;Secret=c2VjcmV0");
+```
+
+#### Microsoft Entra ID
+
+The emulator may be configured to authenticate tokens issued by actual Entra ID by setting the metadata address, valid issuer and valid audience using the environment variables `Authentication__Schemes__MicrosoftEntraId__MetadataAddress`, `Authentication__Schemes__MicrosoftEntraId__ValidIssuer` and `Authentication__Schemes__MicrosoftEntraId__ValidAudience` respectively.
+
+```csharp
+var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator:1.0")
+    .WithPortBinding(8080, true)
+    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
+    .WithEnvironment(
+        "Authentication__Schemes__MicrosoftEntraId__MetadataAddress",
+        $"https://login.microsoftonline.com/{tenantId}/.well-known/openid-configuration")
+    .WithEnvironment(
+        "Authentication__Schemes__MicrosoftEntraId__ValidIssuer",
+        $"https://sts.windows.net/{tenantId}/")
+    .WithEnvironment(
+        "Authentication__Schemes__MicrosoftEntraId__ValidAudience",
+        "https://azconfig.io")
+    .Build();
+
+var credential = new DefaultAzureCredential();
+var client = new ConfigurationClient(endpoint, credential);
+```
+
+Alternatively, [Assumed Identity](https://github.com/nagyesta/assumed-identity) may be used to simulate how Azure Instance Metadata Service (IMDS) handles Managed Identity tokens, enabling real Entra ID integration without an actual Azure environment.
+
+```csharp
+var network = new NetworkBuilder()
+    .Build();
+
+var assumedIdentityContainer = new ContainerBuilder("nagyesta/assumed-identity")
+    .WithNetwork(network)
+    .WithNetworkAliases("assumed-identity")
+    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Started AssumedIdentity"))
+    .Build();
+
+var container = new ContainerBuilder("tnc1997/azure-app-configuration-emulator:1.0")
+    .WithPortBinding(8080, true)
+    .WithNetwork(network)
+    .WithWaitStrategy(Wait.ForUnixContainer().UntilMessageIsLogged("Now listening on"))
+    .WithEnvironment(
+        "Authentication__Schemes__MicrosoftEntraId__MetadataAddress",
+        "http://assumed-identity/metadata/identity/.well-known/openid-configuration")
+    .WithEnvironment(
+        "Authentication__Schemes__MicrosoftEntraId__RequireHttpsMetadata",
+        "false")
+    .Build();
+
+await network.CreateAsync();
+await assumedIdentityContainer.StartAsync();
+await container.StartAsync();
+
+var credential = new ManagedIdentityCredential();
+var client = new ConfigurationClient(new Uri($"http://{container.Hostname}:{container.GetMappedPublicPort(8080)}"), credential);
 ```


### PR DESCRIPTION
**Describe the change**
Document configuration options for working with Test Containers and Entra ID.

**Current behavior**
ValidAudience configuration is not documented.

**New behavior**
Users have examples of how to use the new Entra ID support with Test Containers.

**Additional context**
AI agent struggled to figure out how to do this because it wasn't documented, and its instinct was to use real Entra ID because it was already enabled in the test environment. But it couldn't because the current implementation assumes the Entra ID emulator is in use.
